### PR TITLE
Enable passwordless access by adding '-B' to Dropbear default arguments

### DIFF
--- a/board/ti/am62x-sk/rootfs-overlay/etc/default/dropbear
+++ b/board/ti/am62x-sk/rootfs-overlay/etc/default/dropbear
@@ -1,0 +1,1 @@
+DROPBEAR_ARGS="-B"


### PR DESCRIPTION
Added a new configuration file in "/etc/default/dropbear" to include the `-B` option in Dropbear default arguments via the Buildroot rootfs overlay. This update simplifies remote access to AM62x Buildroot image.